### PR TITLE
[Website] Add docker setup for local builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# Build and cache directories
+build/
+.hugo_build.lock
+dist/
+node_modules/
+
+# Version control
+.git/
+.gitignore
+.github/
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Documentation
+CONTRIBUTING.md
+CODEOWNERS
+
+# Development files
+.env
+.env.local
+*.log
+
+# OS files
+Thumbs.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,77 @@
+# Multi-stage build for HLSL TC57 website with Hugo and LaTeX
+
+# Stage 1: Builder
+FROM ubuntu:22.04
+
+# Set environment variables
+ENV HUGO_VERSION=0.148.1 \
+    DEBIAN_FRONTEND=noninteractive \
+    HUGO_ENVIRONMENT=production
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    wget \
+    git \
+    cmake \
+    build-essential \
+    texlive \
+    texlive-latex-extra \
+    inkscape \
+    unzip \
+    npm \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Hugo extended and Pandoc for the container architecture
+RUN arch=$(dpkg --print-architecture) \
+    && case "$arch" in \
+      amd64) HUGO_ARCH=amd64 PANDOC_ARCH=amd64 ;; \
+      arm64|arm64v8) HUGO_ARCH=arm64 PANDOC_ARCH=arm64 ;; \
+      aarch64) HUGO_ARCH=arm64 PANDOC_ARCH=arm64 ;; \
+      *) echo "Unsupported architecture: $arch" >&2 ; exit 1 ;; \
+    esac \
+    && wget -O /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-${HUGO_ARCH}.deb \
+    && dpkg -i /tmp/hugo.deb \
+    && rm /tmp/hugo.deb \
+    && wget -O /tmp/pandoc.deb https://github.com/jgm/pandoc/releases/download/3.1.9/pandoc-3.1.9-1-${PANDOC_ARCH}.deb \
+    && dpkg -i /tmp/pandoc.deb \
+    && rm /tmp/pandoc.deb
+
+# Install Dart Sass
+RUN npm install -g sass
+
+# Set working directory
+WORKDIR /workspace
+
+# Copy the entire repository
+COPY . .
+
+# Install Node.js dependencies for the theme
+RUN if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then npm ci; fi || true
+
+# Build LaTeX specification
+RUN cmake -B build ./spec \
+    && cmake --build build --target html-chunked \
+    && cmake --build build --target pdf
+
+# Build Hugo website
+RUN cd website \
+    && hugo \
+    --minify \
+    --baseURL "/"
+
+# Copy LaTeX outputs to Hugo public directory
+RUN mkdir -p website/public/spec/assets \
+    && cp spec/assets/* website/public/spec/assets/ 2>/dev/null || true \
+    && cp build/hlsl.pdf website/public/spec/ \
+    && unzip build/html/hlsl.zip -d website/public/spec/
+
+# Stage 2: Runtime (optional - for serving the built site)
+FROM nginx:alpine
+
+COPY --from=0 /workspace/website/public /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Multi-stage build for HLSL TC57 website with Hugo and LaTeX
 
 # Stage 1: Builder
-FROM ubuntu:22.04
+FROM ubuntu:22.04 AS build
 
 # Set environment variables
 ENV HUGO_VERSION=0.148.1 \
@@ -68,9 +68,9 @@ RUN mkdir -p website/public/spec/assets \
     && unzip build/html/hlsl.zip -d website/public/spec/
 
 # Stage 2: Runtime (optional - for serving the built site)
-FROM nginx:alpine
+FROM nginx:alpine AS runtime
 
-COPY --from=0 /workspace/website/public /usr/share/nginx/html
+COPY --from=builder /workspace/website/public /usr/share/nginx/html
 
 EXPOSE 80
 

--- a/README.md
+++ b/README.md
@@ -62,3 +62,8 @@ sudo apt install inkscape
 sudo apt install pandoc
 sudo apt install cmake
 ```
+
+### Website build
+
+See the full documentation on [building the website with
+Docker](docs/Docker.md).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  hlsl-website:
+    build: .
+    ports:
+      - "80:80"
+    environment:
+      - HUGO_ENVIRONMENT=production
+    restart: unless-stopped

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -81,3 +81,6 @@ Make sure all required LaTeX packages are installed. The Dockerfile includes `te
 
 ### Large image size
 This is expected due to full TeX Live installation (~600MB). For production, consider a separate LaTeX build step or using a more minimal TeX distribution.
+
+### Seeing "Welcome to nginx!"
+Ensure you have the most up-to-date version of the hugo-theme-techdoc submodule.

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -1,0 +1,83 @@
+# Building the HLSL TC57 Website with Docker
+
+This Dockerfile builds the complete HLSL TC57 website, including both the Hugo static site and the LaTeX specification.
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+- Approximately 2GB of disk space for the build
+- ~5-10 minutes build time (depending on system)
+
+## Quick Start
+
+### Option 1: Using Docker Compose (Recommended)
+
+```bash
+docker-compose build
+docker-compose up
+```
+
+The website will be available at `http://localhost`
+
+### Option 2: Using Docker Directly
+
+```bash
+# Build the image
+docker build -t hlsl-website .
+
+# Run the container
+docker run -p 80:80 hlsl-website
+```
+
+## Build Details
+
+The Dockerfile performs the following steps:
+
+1. **System Dependencies**: Installs required packages including CMake, LaTeX, Inkscape, Pandoc, and Node.js
+2. **Hugo**: Installs Hugo Extended v0.148.1 and Dart Sass
+3. **Node Dependencies**: Installs theme and website dependencies
+4. **LaTeX Build**: Builds the specification using CMake, producing:
+   - PDF specification (`hlsl.pdf`)
+   - HTML specification (`hlsl.zip` with chunked HTML)
+5. **Hugo Build**: Generates the static website
+6. **Artifact Assembly**: Copies LaTeX outputs to the Hugo public directory
+7. **Nginx**: Serves the final website via Nginx
+
+## Output
+
+After a successful build, the website is available at `http://localhost` with:
+- Hugo-generated website content
+- Embedded LaTeX specification PDF
+- Chunked HTML specification
+
+## Building Without Serving
+
+To build only without running the Nginx server, you can modify the `docker-compose.yml` or use:
+
+```bash
+docker build -t hlsl-website . --target 0
+```
+
+Then copy the output from `/workspace/website/public`:
+
+```bash
+docker run --rm -v $(pwd)/website/public:/output hlsl-website:latest cp -r /workspace/website/public /output
+```
+
+## Development Notes
+
+- The build is multi-stage; the first stage builds everything, the second stage serves via Nginx
+- Build artifacts are cached in the container, so subsequent builds are faster
+- The LaTeX build requires a full TeX Live installation (~600MB)
+- Node dependencies are optional and only installed if `package-lock.json` or `npm-shrinkwrap.json` exist
+
+## Troubleshooting
+
+### Build fails with "CMake not found"
+Ensure the `spec/CMakeLists.txt` file exists and is properly configured.
+
+### LaTeX build fails
+Make sure all required LaTeX packages are installed. The Dockerfile includes `texlive-latex-extra` which contains most common packages.
+
+### Large image size
+This is expected due to full TeX Live installation (~600MB). For production, consider a separate LaTeX build step or using a more minimal TeX distribution.

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -55,7 +55,7 @@ After a successful build, the website is available at `http://localhost` with:
 To build only without running the Nginx server, you can modify the `docker-compose.yml` or use:
 
 ```bash
-docker build -t hlsl-website . --target 0
+docker build -t hlsl-website . --target build
 ```
 
 Then copy the output from `/workspace/website/public`:


### PR DESCRIPTION
This just adds some docker infrastructure to make it easy to locally build and host the website for testing.

Assisted-by: Raptor mini