### PR TITLE
[New] Add proposal for `hlsl` namespace

### DIFF
--- a/proposals/0009-hlsl-namespace.md
+++ b/proposals/0009-hlsl-namespace.md
@@ -1,5 +1,5 @@
 ---
-title: NNNN - HLSL Namespace
+title: 0009 - HLSL Namespace
 params:
     authors:
     - llvm-beanz: Chris Bieneman

--- a/proposals/NNNN-hlsl-namespace.md
+++ b/proposals/NNNN-hlsl-namespace.md
@@ -32,7 +32,7 @@ into a namespace will enable this use case as well.
 
 Each HLSL data type and builtin function will be moved from global scope to the
 `hlsl` namespace. This can be implemented in the AST construction, HLSL headers,
-and other lookup hooks. This would apply to all built in types (`vector`,
-`matrix`, `Texture`, `Buffer`, etc), as well as to their typedefs (`float3`,
-`float3x3`, etc), and to all builtin functions (`DeviceMemoryBarrier`,
+and other lookup hooks. This would apply to all built-in types (`vector`,
+`matrix`, `Texture*`, `Buffer`, etc), as well as to their typedefs (`float3`,
+`float3x3`, etc), and to all built-in functions (`DeviceMemoryBarrier`,
 `WaveIsFirstLane`, etc) including math operations (`abs`, `sin`, etc).

--- a/proposals/NNNN-hlsl-namespace.md
+++ b/proposals/NNNN-hlsl-namespace.md
@@ -1,0 +1,38 @@
+---
+title: NNNN - HLSL Namespace
+params:
+    authors:
+    - llvm-beanz: Chris Bieneman
+    sponsors:
+    - llvm-beanz: Chris Bieneman
+    status: Under Consideration
+---
+
+* Planned Version: 202y
+
+## Introduction
+
+Following conventions of other languages HLSL data types should be moved into a
+namespace so that they can be disambiguated.
+
+## Motivation
+
+As HLSL is evolving to be more source compatible with C++, some HLSL names will
+begin to conflict with C++ names which mean very different things (i.e.
+`vector`) and other names which have subtly different usage (i.e. `sin` vs
+`sinf`). Moving HLSL library functionality into a namespace removes the
+ambiguity and will prevent common errors in the future as HLSL becomes more
+C++-like.
+
+We have also received requests in the past to allow developers to
+define their own versions of built-in functions. Moving the built-in versions
+into a namespace will enable this use case as well.
+
+## Proposed solution
+
+Each HLSL data type and builtin function will be moved from global scope to the
+`hlsl` namespace. This can be implemented in the AST construction, HLSL headers,
+and other lookup hooks. This would apply to all built in types (`vector`,
+`matrix`, `Texture`, `Buffer`, etc), as well as to their typedefs (`float3`,
+`float3x3`, etc), and to all builtin functions (`DeviceMemoryBarrier`,
+`WaveIsFirstLane`, etc) including math operations (`abs`, `sin`, etc).

--- a/proposals/NNNN-hlsl-namespace.md
+++ b/proposals/NNNN-hlsl-namespace.md
@@ -31,6 +31,6 @@ into a namespace will enable this use case as well.
 Each HLSL data type and builtin function will be moved from global scope to the
 `hlsl` namespace. This can be implemented in the AST construction, HLSL headers,
 and other lookup hooks. This would apply to all built-in types (`vector`,
-`matrix`, `Texture*`, `Buffer`, etc), as well as to their typedefs (`float3`,
+`matrix`, textures, buffers, etc), as well as to their typedefs (`float3`,
 `float3x3`, etc), and to all built-in functions (`DeviceMemoryBarrier`,
 `WaveIsFirstLane`, etc) including math operations (`abs`, `sin`, etc).

--- a/proposals/NNNN-hlsl-namespace.md
+++ b/proposals/NNNN-hlsl-namespace.md
@@ -8,8 +8,6 @@ params:
     status: Under Consideration
 ---
 
-* Planned Version: 202y
-
 ## Introduction
 
 Following conventions of other languages HLSL data types should be moved into a


### PR DESCRIPTION
This proposal introduces a new `hlsl` namespace and denotes that names defined in the standard should be placed in the `hlsl` namespace instead of the global namespace.