### PR TITLE
[Resources] Add resources clause and typed buffers

### DIFF
--- a/spec/glossary.tex
+++ b/spec/glossary.tex
@@ -42,6 +42,12 @@
   description={Standard for Programming Language C++.}
 }
 
+\newglossaryentry{isoCPP20}
+{
+  name={ISO/IEC 14882:2020},
+  description={Standard for Programming Language C++.}
+}
+
 \newglossaryentry{IEEE754}
 {
   name={ISO/IEC 60559:2020},

--- a/spec/hlsl.tex
+++ b/spec/hlsl.tex
@@ -72,6 +72,9 @@
 \input{conversions}
 \input{expressions}
 \input{declarations}
+
+% Standard library clauses
+\input{resources}
 \clearpage
 
 \input{annex-a}

--- a/spec/hlsl.tex
+++ b/spec/hlsl.tex
@@ -74,6 +74,7 @@
 \input{declarations}
 
 % Standard library clauses
+\input{library}
 \input{resources}
 \clearpage
 

--- a/spec/library.tex
+++ b/spec/library.tex
@@ -9,7 +9,10 @@ objects.
 \p Some of the constructs in the standard library are not expressible with
 spellable syntax. This section describes syntax constructs which are
 non-standard but are used throughout the standard library specification.
-All code blocks in the library clauses are non-normative.
+
+\p Code blocks in the remaining clauses of the specification decribe a
+hypothetical implementation and are provided for clarity. A conforming
+implementation need not rely on the specifc code in any of the blocks. 
 
 \Sub{Constructors}{Library.Notation.Constructors}
 

--- a/spec/library.tex
+++ b/spec/library.tex
@@ -1,0 +1,31 @@
+\Ch{Library Overview}{Library}
+
+\p This clause serves as an overview to the remaining clauses of the
+specification which detail \acrshort{hlsl}'s standard library of functions and
+objects.
+
+\Sec{Syntax Notations}{Library.Notation}
+
+\p Some of the constructs in the standard library are not expressible with
+spellable syntax. This section describes syntax constructs which are
+non-standard but are used throughout the standard library specification.
+
+\Sub{Constructors}{Library.Notation.Constructors}
+
+\p Some standard library types have behaviors associated in \gls{isoCPP} with
+constructors. These syntaxes are intended to describe compatible behavior with
+C++ constructors.
+
+\Sub{Reference Types}{Library.Notation.References}
+
+\p Some standard library functions or member functions behave as if a parameter
+or return value are references (passed by address or returned by address). To
+simplify this notation the syntax \textit{address-space\textsubscript{opt}}
+\texttt{T \&} is used where the optional \textit{address-space} is one of
+\texttt{device} or \texttt{groupshared}.
+
+\Sub{Concepts}{Library.Notation.Concepts}
+
+\p Some standard library template functions or objects have constraints to which
+types are valid as template arguments. To simplify this notation the concepts
+syntax from \gls{isoCPP20} is used.

--- a/spec/library.tex
+++ b/spec/library.tex
@@ -79,11 +79,11 @@ of any introduced headers, macros, and declarations.
 that apply:
 
 \begin{itemize}
-  \item name and description
-  \item class definition or function prototype
-  \item template argument constraints
-  \item class invariants
-  \item function semantics
+  \item Name and description
+  \item Class definition or function prototype
+  \item Template argument constraints
+  \item Class invariants
+  \item Function semantics
 \end{itemize}
 
 \p Description of class member functions will follow the order, omitting

--- a/spec/library.tex
+++ b/spec/library.tex
@@ -12,7 +12,7 @@ non-standard but are used throughout the standard library specification.
 
 \p Code blocks in the remaining clauses of the specification decribe a
 hypothetical implementation and are provided for clarity. A conforming
-implementation need not rely on the specifc code in any of the blocks. 
+implementation need not rely on the specifc code in any of the blocks.
 
 \Sub{Constructors}{Library.Notation.Constructors}
 
@@ -33,3 +33,80 @@ simplify this notation the syntax \textit{address-space\textsubscript{opt}}
 \p Some standard library template functions or objects have constraints to which
 types are valid as template arguments. To simplify this notation the concepts
 syntax from \gls{isoCPP20} is used.
+
+\Sec{Method of Description (Informative)}{Library.Method}
+
+\Sub{Clause Structure}{Libarry.Method.Structure}
+
+\p Each library clause will contain all applicable subclauses of the list:
+
+\begin{itemize}
+  \item Introduction
+  \item Optional features
+  \item Special semantics
+  \item Element subclauses
+\end{itemize}
+
+\p The clause introduction shall provide an overview of the contents of the
+clause. Some features detailed in a clause may be optional, a subclause
+describing the optional features will be included if applicable.
+
+\p Each library clause will optionally contain a subclause describing additional
+semantic behaviors required for the clause. This subclause is omitted if empty.
+
+\p Each library clause will contain one or more element subclauses detailing the
+declarations required in a conforming implementation of the specification, and
+any normative optional declarations based on optional features described in the
+clause.
+
+\SubSub{Element Subclauses}{Library.Method.Structure.Element}
+
+\p Each element subclause contain the following:
+
+\begin{itemize}
+  \item Summary
+  \item Detailed specifications
+\end{itemize}
+
+\SubSub{Summary}{Library.Method.Structure.Summary}
+
+\p The summary will include a description of the category as well as a listing
+of any introduced headers, macros, and declarations.
+
+\SubSub{Detailed Specification}{Library.Method.Structure.Detailed}
+
+\p The detailed specification for each entity will contain each of the below
+that apply:
+
+\begin{itemize}
+  \item name and description
+  \item class definition or function prototype
+  \item template argument constraints
+  \item class invariants
+  \item function semantics
+\end{itemize}
+
+\p Description of class member functions will follow the order, omitting
+sections that are empty:
+
+\begin{itemize}
+  \item Constructors
+  \item Copying and assignment
+  \item Modifying functions
+  \item Inspection functions
+  \item Operators
+  \item Other non-member functions
+\end{itemize}
+
+\p Descriptions of function semantics will contain all of the following elements
+that apply in the order as specified:
+
+\begin{itemize}
+  \item \textit{Requires:} the preconditions for calling the function.
+  \item \textit{Effects:} the actions performed by the function.
+  \item \textit{Synchronization:} the requirements for execution or memory
+  synchronization.
+  \item \textit{Returns:} a description of the value returned by the function.
+  \item \textit{Remarks:} additional normative information about the function.
+  \item \textit{Notes:} non-normative information provided about the function.
+\end{itemize}

--- a/spec/library.tex
+++ b/spec/library.tex
@@ -9,6 +9,7 @@ objects.
 \p Some of the constructs in the standard library are not expressible with
 spellable syntax. This section describes syntax constructs which are
 non-standard but are used throughout the standard library specification.
+All code blocks in the library clauses are non-normative.
 
 \Sub{Constructors}{Library.Notation.Constructors}
 

--- a/spec/library.tex
+++ b/spec/library.tex
@@ -12,7 +12,7 @@ non-standard but are used throughout the standard library specification.
 
 \p Code blocks in the remaining clauses of the specification decribe a
 hypothetical implementation and are provided for clarity. A conforming
-implementation need not rely on the specifc code in any of the blocks.
+implementation need not rely on the specific code in any of the blocks.
 
 \Sub{Constructors}{Library.Notation.Constructors}
 

--- a/spec/library.tex
+++ b/spec/library.tex
@@ -13,7 +13,7 @@ non-standard but are used throughout the standard library specification.
 \Sub{Constructors}{Library.Notation.Constructors}
 
 \p Some standard library types have behaviors associated in \gls{isoCPP} with
-constructors. These syntaxes are intended to describe compatible behavior with
+constructors. These syntaxes are intended to describe equivalent behavior with
 C++ constructors.
 
 \Sub{Reference Types}{Library.Notation.References}

--- a/spec/resources.tex
+++ b/spec/resources.tex
@@ -157,7 +157,7 @@ T Load(uint index) const;
 \end{HLSL}
 
 \begin{itemize}
-  \item \textit{Requires:} \texttt{index} < the number of elements in the
+  \item \textit{Requires:} \texttt{index} \textless the number of elements in the
   typed buffer.
   \item \textit{Returns:} The element in the typed buffer at the index specified
   by \texttt{index}.
@@ -188,7 +188,7 @@ T operator[](uint index) const;
 \end{HLSL}
 
 \begin{itemize}
-  \item \textit{Requires:} \texttt{index} < the number of elements in the
+  \item \textit{Requires:} \texttt{index} \textless the number of elements in the
   typed buffer.
   \item \textit{Returns:} The element in the typed buffer at the index specified
   by \texttt{index}.
@@ -199,7 +199,7 @@ device T &operator[](int index);
 \end{HLSL}
 
 \begin{itemize}
-  \item \textit{Preconditions:} \texttt{index} < the number of elements in the
+  \item \textit{Preconditions:} \texttt{index} \textless the number of elements in the
   typed buffer.
   \item \textit{Returns:} An lvalue-reference to the element in the typed buffer
   at the index specified by \texttt{index}.

--- a/spec/resources.tex
+++ b/spec/resources.tex
@@ -1,6 +1,7 @@
 \Ch{Resource Types}{Resources}
 
-\p Resource types are intangible types representing memory or configuration with an external interface.
+\p Resource types are intangible types representing memory or configuration with
+an external interface.
 
 \p These take the form of typed buffers, raw buffers, textures, constant buffers
 and samplers.
@@ -36,7 +37,7 @@ subscript indexing into the \texttt{ResourceDescriptorHeap}
 \p A resource declaration in a global scope are called \textit{global
 resource declaration} and represents a binding for external data into a
 program. Global resource declarations are implicitly initialized in an
-implementation-defined.
+implementation-defined way.
 
 \p Use of an uninitialized resource is undefined.
 

--- a/spec/resources.tex
+++ b/spec/resources.tex
@@ -1,0 +1,177 @@
+\Ch{Resource Types}{Resources}
+
+\p Resources are intangible types representing memory with an external interface.
+
+\p These take the form of Typed Buffers, Raw Buffers, Textures, Constant Buffers
+and Samplers.
+
+\p Typed Buffer, Raw Buffer, and Texture resources may be read-only or
+read-write as denoted by the type of the resource, where the names of read-write
+resources are prefixed with \texttt{RW}.
+
+\begin{note}
+The resource class objects in this clause require language behaviors not
+defined in the current language. Specifically, they utilize constructor
+behaviors, reference types, and concepts (for constraining instantiation). For
+ease of reading this clause uses C++ syntax to represent those language
+constructs. Additionally this clause assumes the introduction of the
+\texttt{device} keyword to denote references to device memory.
+\end{note}
+
+\p Global resource declarations are \textit{bound} to device memory managed by
+an application through a runtime implementation. A resource declaration that is
+not bound is said to be \textit{unbound}. Operations on unbound resources are
+evaluated as no-ops.
+
+\p An implementation may impose restrictions on how local resource objects may
+be used (\ref{AnnexB.LocalResources}).
+
+\Sec{Typed Buffers}{Resources.TypedBuffers}
+
+\p The typed buffer class template represents a one-dimensional resource
+containing an array of a single given type. Its contents are indexed by typed
+access to each element. Types may have their formats converted upon load in an
+implementation-defined way.
+
+\p The element type may be any type up to 16 bytes in size. Elements may be
+padded to 16 bytes if the element type is smaller than 16 bytes.
+
+\p All typed buffers can be read through subscript operators or Load methods.
+Writable typed buffers can be written through subscript operators.
+
+\p Where \texttt{T} can be any arithmetic type \ref{Basic.Types.Arithmetic}
+or a vector with a maximum of four elements containing such an arithmetic type.
+The total size of a single contained element must be less than 16 bytes.
+
+\p Typed buffers perform format conversions on load such that the underlying
+data gets converted to the destination type in an implementation-defined way.
+
+\begin{HLSL}
+template <typename T = float4> requires hlsl::is_vector<T>::value || hlsl::is_arithmetic<T>::value
+class Buffer {
+  Buffer();
+  Buffer(const Buffer &buf);
+  Buffer &operator=(Buffer &buf);
+  Buffer(const __DynamicResourceHandle &handle);
+
+  void GetDimensions(out uint width) const;
+
+  // Element access.
+  T operator[](int index) const;
+  T Load(int index) const;
+  T Load(int index, out uint status) const;
+};
+
+
+template <typename T> requires hlsl::is_vector<T>::value || hlsl::is_arithmetic<T>::value
+class RWBuffer {
+  RWBuffer();
+  RWBuffer(RWBuffer buf);
+  RWBuffer &operator=(RWBuffer &buf);
+  Buffer(const __DynamicResourceHandle &handle);
+
+  void GetDimensions(out uint width) const;
+
+  // Element access.
+  T operator[](int index) const;
+  device T &operator[](int n) const;
+  T Load(int index) const;
+  T Load(int index, out uint status) const;
+};
+\end{HLSL}
+
+\Sub{Constructors}{Resources.TypedBuffers.Ctrs}
+
+\p When defined at global scope, typed buffers are bound to externally-defined
+backing stores using the explicit binding location if provided or the implicit
+binding if not (\ref{Resources.Binding}).
+
+\p When defined at local scope, typed buffers represent local references that
+can be associated with global buffers when assigned. Use of an uninitialized
+typed buffer is undefined.
+
+\begin{HLSL}
+Buffer<int> grobuf;
+RWBuffer<int> grwbuf;
+void main() {
+  Buffer<int> lrobuf = grobuf;
+  RWBuffer<int> lrwbuf = grwbuf;
+}
+\end{HLSL}
+
+\p Buffers cannot be implicitly nor explicitly cast from one type to another.
+
+\p Buffers may be created from dynamic resources. The
+\texttt{\_\_DynamicResourceHandle} type in the examples above is a placeholder
+for the implementation-specific type returned by subscript indexing into the
+\texttt{ResourceDescriptorHeap} (\ref{Resources.Binding.Dynamic}).
+
+\Sub{Dimensions}{Resources.TypedBuffers.Dims}
+
+\p The size of a typed buffer can be retrieved using the \texttt{GetDimensions}
+method.
+
+\begin{HLSL}
+void GetDimensions(out uint width) const;
+\end{HLSL}
+
+\p This returns the full length, in elements of the buffer through the
+\texttt{width} output parameter.
+
+\Sub{Element Access}{Resources.TypedBuffers.Access}
+
+\p The contents of typed buffers can be retrieved using the \texttt{Load} methods
+or the subscript operator.
+
+\begin{HLSL}
+T Load(in int index) const;
+T operator[](int index) const;
+\end{HLSL}
+
+\p These each return the element of the buffer's type at the given index
+\texttt{index}.
+
+\p An additional \texttt{Load} method returns the indicated element just as the
+other, but also takes a second \texttt{status} parameter that returns
+information about the accessed resource.
+
+\begin{HLSL}
+T Load(in int index, out uint status) const;
+\end{HLSL}
+
+\p The \texttt{status} parameter returns an indication of whether all of the
+retrieved value came from fully mapped parts of the resource. This parameter
+must be passed to the built-in function \texttt{CheckAccessFullyMapped}
+(\ref{Resources.Mapcheck}) in order to interpret it.
+
+\p Writable buffers have an additional subscript operator that allows assignment
+to an element of the buffer. It behaves as if it returns a reference to that
+element as stored in device memory.
+
+\begin{HLSL}
+device T &operator[](int index);
+\end{HLSL}
+
+\begin{note}
+  Accurately modeling the memory operations for writable typed buffers would
+  require a proxy-object interface since the address written to isn't actually
+  the device memory since it may be converted or otherwise normalized by the
+  implementation.
+\end{note}
+
+\p Writes to typed buffer elements overwrite the entire element, even if only
+part of the data is written. The behavior of partial writes is
+implementation-defined.
+
+\Sec{CheckAccessFullyMapped}{Resources.mapcheck}
+
+\p The mapped status value returned by certain texture and buffer methods can be
+intrepreted by a built-in function:
+
+\begin{HLSL}
+bool CheckAccessFullyMapped(uint status);
+\end{HLSL}
+
+\p This function returns true if the value was accessed from memory that was
+mapped by the runtime implementation. If any part of the return value was from
+unmapped memory, false is returned.

--- a/spec/resources.tex
+++ b/spec/resources.tex
@@ -9,15 +9,6 @@ and Samplers.
 read-write as denoted by the type of the resource, where the names of read-write
 resources are prefixed with \texttt{RW}.
 
-\begin{note}
-The resource class objects in this clause require language behaviors not
-defined in the current language. Specifically, they utilize constructor
-behaviors, reference types, and concepts (for constraining instantiation). For
-ease of reading this clause uses C++ syntax to represent those language
-constructs. Additionally this clause assumes the introduction of the
-\texttt{device} keyword to denote references to device memory.
-\end{note}
-
 \p Global resource declarations are \textit{bound} to device memory managed by
 an application through a runtime implementation. A resource declaration that is
 not bound is said to be \textit{unbound}. Operations on unbound resources are

--- a/spec/resources.tex
+++ b/spec/resources.tex
@@ -34,7 +34,7 @@ subscript indexing into the \texttt{ResourceDescriptorHeap}
 
 \Sub{Resource Initialization}{Resources.Special.Initialization}
 
-\p A resource declaration in a global scope are called \textit{global
+\p A resource declaration in a global scope is called a \textit{global
 resource declaration} and represents a binding for external data into a
 program. Global resource declarations are implicitly initialized in an
 implementation-defined way.
@@ -45,7 +45,7 @@ implementation-defined way.
 
 \p The typed buffer class template represents a one-dimensional resource
 containing an array of a single given type. Its contents are indexed by typed
-access to each element. The memory backing a resource need not formatted in the
+access to each element. The memory backing a resource need not be formatted in the
 same type as the resource's element type. If required, typed buffer elements are
 converted upon load in an implementation-defined way.
 
@@ -199,7 +199,7 @@ device T &operator[](int index);
 \end{HLSL}
 
 \begin{itemize}
-  \item \textit{Preconditions:} \texttt{index} \textless the number of elements in the
+  \item \textit{Requires:} \texttt{index} \textless the number of elements in the
   typed buffer.
   \item \textit{Returns:} An lvalue-reference to the element in the typed buffer
   at the index specified by \texttt{index}.
@@ -225,7 +225,7 @@ bool CheckAccessFullyMapped(uint status);
 \end{HLSL}
 
 \begin{itemize}
-  \item \textit{Preconditions:} \texttt{status} is an initialized value from a
+  \item \textit{Requires:} \texttt{status} is an initialized value from a
   resource \texttt{Load} function's \texttt{status} output parameter.
   \item \textit{Returns:} \texttt{true} if the value was accessed from memory
   that was fully mapped by the runtime implementation; otherwise returns

--- a/spec/resources.tex
+++ b/spec/resources.tex
@@ -90,9 +90,9 @@ class RWBuffer {
 \end{HLSL}
 
 \p The element type of a typed buffer, \texttt{T}, must be an arithmetic type
-(\ref{Basic.Types.Arithmetic}) or vector of arithmetic containing no more than 4
-elements, and the total size of the element (\texttt{sizeof(T)}) must not exceed
-16-bytes in size.
+(\ref{Basic.Types.Arithmetic}) or vector of arithmetic type containing no more
+than 4 elements, and the total size of the element (\texttt{sizeof(T)}) must not
+exceed 16-bytes in size.
 
 \p The \texttt{Buffer} type's template argument \texttt{T} has a default value
 of \texttt{float4}.

--- a/spec/resources.tex
+++ b/spec/resources.tex
@@ -37,6 +37,9 @@ The total size of a single contained element must be less than 16 bytes.
 \p Typed buffers perform format conversions on load such that the underlying
 data gets converted to the destination type in an implementation-defined way.
 
+\p The \texttt{Buffer} type's template argument \texttt{T} has a default value
+of \texttt{float4}.
+
 \begin{HLSL}
 template <typename T = float4> requires hlsl::is_vector<T>::value || hlsl::is_arithmetic<T>::value
 class Buffer {
@@ -115,8 +118,8 @@ void GetDimensions(out uint width) const;
 or the subscript operator.
 
 \begin{HLSL}
-T Load(int index) const;
-T operator[](int index) const;
+T Load(uint index) const;
+T operator[](uint index) const;
 \end{HLSL}
 
 \p These each return the element of the buffer's type at the given index
@@ -151,8 +154,8 @@ device T &operator[](int index);
 \end{note}
 
 \p Writes to typed buffer elements overwrite the entire element, even if only
-part of the data is written. The behavior of partial writes is
-implementation-defined.
+part of the data is written. A partial write to a typed buffer is a load of the
+full value, an insert of the partial elements, then a write of the full value.
 
 \Sec{CheckAccessFullyMapped}{Resources.mapcheck}
 

--- a/spec/resources.tex
+++ b/spec/resources.tex
@@ -1,13 +1,13 @@
 \Ch{Resource Types}{Resources}
 
-\p Resources are intangible types representing memory with an external interface.
+\p Resource types are intangible types representing memory or configuration with an external interface.
 
 \p These take the form of Typed Buffers, Raw Buffers, Textures, Constant Buffers
 and Samplers.
 
 \p Typed Buffer, Raw Buffer, and Texture resources may be read-only or
 read-write as denoted by the type of the resource, where the names of read-write
-resources are prefixed with \texttt{RW}.
+resource types are prefixed with \texttt{RW}.
 
 \p Global resource declarations are \textit{bound} to device memory managed by
 an application through a runtime implementation. A resource declaration that is
@@ -115,7 +115,7 @@ void GetDimensions(out uint width) const;
 or the subscript operator.
 
 \begin{HLSL}
-T Load(in int index) const;
+T Load(int index) const;
 T operator[](int index) const;
 \end{HLSL}
 
@@ -127,7 +127,7 @@ other, but also takes a second \texttt{status} parameter that returns
 information about the accessed resource.
 
 \begin{HLSL}
-T Load(in int index, out uint status) const;
+T Load(int index, out uint status) const;
 \end{HLSL}
 
 \p The \texttt{status} parameter returns an indication of whether all of the

--- a/spec/resources.tex
+++ b/spec/resources.tex
@@ -17,31 +17,44 @@ evaluated as no-ops.
 \p An implementation may impose restrictions on how local resource objects may
 be used (\ref{AnnexB.LocalResources}).
 
+\Sec{Optional Features}{Resources.Optional}
+
+\p \textit{Dynamic resources} is an optional feature which allows resource
+objects to be initialized by indexing directly into a heap of descriptors. A
+conforming implementation must either support all interfaces related to dynamic
+resources or none, but may not partially support them.
+
+\p The \texttt{\_\_DynamicResourceHandle} type in the code examples in this
+clause is a placeholder for the implementation-specific type returned by
+subscript indexing into the \texttt{ResourceDescriptorHeap}
+(\ref{Resources.Binding.Dynamic}).
+
+\Sec{Special Semantics}{Resources.Special}
+
+\Sub{Resource Initialization}{Resources.Special.Initialization}
+
+\p A resource declaration in a global scope are called \textit{global
+resource declaration} and represents a binding for external data into a
+program. Global resource declarations are implicitly initialized in an
+implementation-defined.
+
+\p Use of an uninitialized resource is undefined.
+
 \Sec{Typed Buffers}{Resources.TypedBuffers}
 
 \p The typed buffer class template represents a one-dimensional resource
 containing an array of a single given type. Its contents are indexed by typed
-access to each element. Types may have their formats converted upon load in an
-implementation-defined way.
+access to each element. The memory backing a resource need not formatted in the
+same type as the resource's element type. If required, typed buffer elements are
+converted upon load in an implementation-defined way.
 
-\p The element type may be any type up to 16 bytes in size. Elements may be
-padded to 16 bytes if the element type is smaller than 16 bytes.
-
-\p All typed buffers can be read through subscript operators or Load methods.
-Writable typed buffers can be written through subscript operators.
-
-\p Where \texttt{T} can be any arithmetic type \ref{Basic.Types.Arithmetic}
-or a vector with a maximum of four elements containing such an arithmetic type.
-The total size of a single contained element must be less than 16 bytes.
-
-\p Typed buffers perform format conversions on load such that the underlying
-data gets converted to the destination type in an implementation-defined way.
-
-\p The \texttt{Buffer} type's template argument \texttt{T} has a default value
-of \texttt{float4}.
+\p There are two typed buffer class templates \texttt{Buffer} and
+\texttt{RWBuffer}, which respectively represent read-only and read-write typed
+buffer objects.
 
 \begin{HLSL}
-template <typename T = float4> requires hlsl::is_vector<T>::value || hlsl::is_arithmetic<T>::value
+template <typename T = float4>
+requires hlsl::is_vector<T>::value || hlsl::is_arithmetic<T>::value
 class Buffer {
   Buffer();
   Buffer(const Buffer &buf);
@@ -57,7 +70,8 @@ class Buffer {
 };
 
 
-template <typename T> requires hlsl::is_vector<T>::value || hlsl::is_arithmetic<T>::value
+template <typename T>
+requires hlsl::is_vector<T>::value || hlsl::is_arithmetic<T>::value
 class RWBuffer {
   RWBuffer();
   RWBuffer(RWBuffer buf);
@@ -74,77 +88,124 @@ class RWBuffer {
 };
 \end{HLSL}
 
-\Sub{Constructors}{Resources.TypedBuffers.Ctrs}
+\p The element type of a typed buffer, \texttt{T}, must be an arithmetic type
+(\ref{Basic.Types.Arithmetic}) or vector of arithmetic containing no more than 4
+elements, and the total size of the element (\texttt{sizeof(T)}) must not exceed
+16-bytes in size.
 
-\p When defined at global scope, typed buffers are bound to externally-defined
-backing stores using the explicit binding location if provided or the implicit
-binding if not (\ref{Resources.Binding}).
+\p The \texttt{Buffer} type's template argument \texttt{T} has a default value
+of \texttt{float4}.
 
-\p When defined at local scope, typed buffers represent local references that
-can be associated with global buffers when assigned. Use of an uninitialized
-typed buffer is undefined.
+\Sub{Typed Buffer Constructors}{Resources.TypedBuffers.Ctrs}
 
 \begin{HLSL}
-Buffer<int> grobuf;
-RWBuffer<int> grwbuf;
-void main() {
-  Buffer<int> lrobuf = grobuf;
-  RWBuffer<int> lrwbuf = grwbuf;
-}
+Buffer();
+RWBuffer();
 \end{HLSL}
 
-\p Buffers cannot be implicitly nor explicitly cast from one type to another.
+\begin{itemize}
+  \item \textit{Effects:} Constructs an uninitialized resource handle.
+\end{itemize}
 
-\p Buffers may be created from dynamic resources. The
-\texttt{\_\_DynamicResourceHandle} type in the examples above is a placeholder
-for the implementation-specific type returned by subscript indexing into the
-\texttt{ResourceDescriptorHeap} (\ref{Resources.Binding.Dynamic}).
+\begin{HLSL}
+Buffer(const Buffer &buf);
+RWBuffer(const RWBuffer &buf);
+\end{HLSL}
 
-\Sub{Dimensions}{Resources.TypedBuffers.Dims}
+\begin{itemize}
+  \item \textit{Effects:} Initializes a resource to refer to the same resource
+  as the input argument \texttt{buf}.
+\end{itemize}
 
-\p The size of a typed buffer can be retrieved using the \texttt{GetDimensions}
-method.
+\begin{HLSL}
+Buffer(const __DynamicResourceHandle &handle);
+\end{HLSL}
+
+\begin{itemize}
+  \item \textit{Feature:} Dependent on dynamic resources (\ref{Resources.Binding.Dynamic}).
+  \item \textit{Effects:} Initializes a resource to refer to the dynamic
+  resource handle provided as the input argument \texttt{handle}.
+\end{itemize}
+
+\Sub{Typed Buffer Copying and Assignment}{Resources.TypedBuffers.Copy}
+
+\begin{HLSL}
+Buffer &operator=(Buffer &buf);
+RWBuffer &operator=(RWBuffer &buf);
+\end{HLSL}
+
+\begin{itemize}
+  \item \textit{Effects:} Initializes a resource to refer to the same resource
+  as the input argument \texttt{buf}.
+  \item \textit{Returns:} \texttt{this}.
+\end{itemize}
+
+\Sub{Typed Buffer Inspecting Functions}{Resources.TypedBuffers.Inspect}
 
 \begin{HLSL}
 void GetDimensions(out uint width) const;
 \end{HLSL}
 
-\p This returns the full length, in elements of the buffer through the
-\texttt{width} output parameter.
-
-\Sub{Element Access}{Resources.TypedBuffers.Access}
-
-\p The contents of typed buffers can be retrieved using the \texttt{Load} methods
-or the subscript operator.
+\begin{itemize}
+  \item \textit{Effects:} Writes the total number of elements contained in the
+  typed buffer to the \texttt{width} argument.
+\end{itemize}
 
 \begin{HLSL}
 T Load(uint index) const;
-T operator[](uint index) const;
 \end{HLSL}
 
-\p These each return the element of the buffer's type at the given index
-\texttt{index}.
-
-\p An additional \texttt{Load} method returns the indicated element just as the
-other, but also takes a second \texttt{status} parameter that returns
-information about the accessed resource.
+\begin{itemize}
+  \item \textit{Requires:} \texttt{index} < the number of elements in the
+  typed buffer.
+  \item \textit{Returns:} The element in the typed buffer at the index specified
+  by \texttt{index}.
+\end{itemize}
 
 \begin{HLSL}
 T Load(int index, out uint status) const;
 \end{HLSL}
 
-\p The \texttt{status} parameter returns an indication of whether all of the
-retrieved value came from fully mapped parts of the resource. This parameter
-must be passed to the built-in function \texttt{CheckAccessFullyMapped}
-(\ref{Resources.Mapcheck}) in order to interpret it.
+\begin{itemize}
+  \item \textit{Requires:} \texttt{index} \textless the number of elements in the
+  typed buffer.
+  \item \textit{Returns:} The element in the typed buffer at the index specified
+  by \texttt{index}.
+  \item \textit{Effects:} Initializes the \texttt{status} argument to an
+  implementation-defined status signal (\ref{Resources.Mapcheck}).
+  \item \textit{Remarks:} The \texttt{status} parameter returns an
+  implementation-defined value that indicates if the loaded value came from
+  fully mapped parts of the resource. This parameter must be passed to the
+  built-in function \texttt{CheckAccessFullyMapped} (\ref{Resources.Mapcheck})
+  in order to interpret it.
+\end{itemize}
 
-\p Writable buffers have an additional subscript operator that allows assignment
-to an element of the buffer. It behaves as if it returns a reference to that
-element as stored in device memory.
+\Sub{Typed Buffer Operators}{Resources.TypedBuffers.Operators}
+
+\begin{HLSL}
+T operator[](uint index) const;
+\end{HLSL}
+
+\begin{itemize}
+  \item \textit{Requires:} \texttt{index} < the number of elements in the
+  typed buffer.
+  \item \textit{Returns:} The element in the typed buffer at the index specified
+  by \texttt{index}.
+\end{itemize}
 
 \begin{HLSL}
 device T &operator[](int index);
 \end{HLSL}
+
+\begin{itemize}
+  \item \textit{Preconditions:} \texttt{index} < the number of elements in the
+  typed buffer.
+  \item \textit{Returns:} An lvalue-reference to the element in the typed buffer
+  at the index specified by \texttt{index}.
+  \item \textit{Remarks:} Writing to typed buffer elements overwrite the entire
+  element, even if only part of the data is written. A partial write to a typed
+  buffer is a load-insert-store operation.
+\end{itemize}
 
 \begin{note}
   Accurately modeling the memory operations for writable typed buffers would
@@ -153,19 +214,19 @@ device T &operator[](int index);
   implementation.
 \end{note}
 
-\p Writes to typed buffer elements overwrite the entire element, even if only
-part of the data is written. A partial write to a typed buffer is a load of the
-full value, an insert of the partial elements, then a write of the full value.
+\Sec{CheckAccessFullyMapped}{Resources.Mapcheck}
 
-\Sec{CheckAccessFullyMapped}{Resources.mapcheck}
-
-\p The mapped status value returned by certain texture and buffer methods can be
-intrepreted by a built-in function:
+\p The implementation-defined status value returned by texture and buffer load
+methods is interpreted by a built-in function:
 
 \begin{HLSL}
 bool CheckAccessFullyMapped(uint status);
 \end{HLSL}
 
-\p This function returns true if the value was accessed from memory that was
-mapped by the runtime implementation. If any part of the return value was from
-unmapped memory, false is returned.
+\begin{itemize}
+  \item \textit{Preconditions:} \texttt{status} is an initialized value from a
+  resource \texttt{Load} function's \texttt{status} output parameter.
+  \item \textit{Returns:} \texttt{true} if the value was accessed from memory
+  that was fully mapped by the runtime implementation; otherwise returns
+  \texttt{false}.
+\end{itemize}

--- a/spec/resources.tex
+++ b/spec/resources.tex
@@ -2,10 +2,10 @@
 
 \p Resource types are intangible types representing memory or configuration with an external interface.
 
-\p These take the form of Typed Buffers, Raw Buffers, Textures, Constant Buffers
-and Samplers.
+\p These take the form of typed buffers, raw buffers, textures, constant buffers
+and samplers.
 
-\p Typed Buffer, Raw Buffer, and Texture resources may be read-only or
+\p Typed buffer, raw buffer, and Texture resources may be read-only or
 read-write as denoted by the type of the resource, where the names of read-write
 resource types are prefixed with \texttt{RW}.
 

--- a/spec/resources.tex
+++ b/spec/resources.tex
@@ -157,8 +157,8 @@ T Load(uint index) const;
 \end{HLSL}
 
 \begin{itemize}
-  \item \textit{Requires:} \texttt{index} \textless the number of elements in the
-  typed buffer.
+  \item \textit{Requires:} \texttt{index} \textless\enspace the number of
+  elements in the typed buffer.
   \item \textit{Returns:} The element in the typed buffer at the index specified
   by \texttt{index}.
 \end{itemize}
@@ -168,8 +168,8 @@ T Load(int index, out uint status) const;
 \end{HLSL}
 
 \begin{itemize}
-  \item \textit{Requires:} \texttt{index} \textless the number of elements in the
-  typed buffer.
+  \item \textit{Requires:} \texttt{index} \textless\enspace the number of
+  elements in the typed buffer.
   \item \textit{Returns:} The element in the typed buffer at the index specified
   by \texttt{index}.
   \item \textit{Effects:} Initializes the \texttt{status} argument to an
@@ -188,8 +188,8 @@ T operator[](uint index) const;
 \end{HLSL}
 
 \begin{itemize}
-  \item \textit{Requires:} \texttt{index} \textless the number of elements in the
-  typed buffer.
+  \item \textit{Requires:} \texttt{index} \textless\enspace the number of
+  elements in the typed buffer.
   \item \textit{Returns:} The element in the typed buffer at the index specified
   by \texttt{index}.
 \end{itemize}
@@ -199,8 +199,8 @@ device T &operator[](int index);
 \end{HLSL}
 
 \begin{itemize}
-  \item \textit{Requires:} \texttt{index} \textless the number of elements in the
-  typed buffer.
+  \item \textit{Requires:} \texttt{index} \textless\enspace the number of
+  elements in the typed buffer.
   \item \textit{Returns:} An lvalue-reference to the element in the typed buffer
   at the index specified by \texttt{index}.
   \item \textit{Remarks:} Writing to typed buffer elements overwrite the entire


### PR DESCRIPTION
This adds the typed buffer section of the resources clause. There are some unresolved references to other sections in the resources clause that are yet to be filled out, but this is a good starting point.