### PR TITLE
Agenda for 2026-07-07 meeting

### DIFF
--- a/docs/Meetings/2026-07-07-agenda.md
+++ b/docs/Meetings/2026-07-07-agenda.md
@@ -23,6 +23,9 @@ title: "TC57 Meeting Agenda: 2026/07/07"
 
 # 2 Approval of prior meeting minutes
 
+* 2026-06-09 - https://github.com/hlsl-tc57/tc57/pull/129
+* 2026-06-23 - https://github.com/hlsl-tc57/tc57/pull/132
+
 # 3 Review of the agenda
 
 # 4 Editorial Board Report
@@ -51,8 +54,11 @@ title: "TC57 Meeting Agenda: 2026/07/07"
   * Question about conversion operators - https://hlsl.godbolt.org/z/d4zWo59vf -
     what should we allow?
 * For 2026-07-21
-  * **Normative Change** `[Lex.Identifier]` - https://github.com/hlsl-tc57/tc57/pull/119
-  * **New Proposal** - Ternary operator behavior - https://github.com/hlsl-tc57/tc57/pull/122
+  * **Normative Change** `[Lex.Identifier]` -
+    https://github.com/hlsl-tc57/tc57/pull/119
+  * New Proposals:
+    * **New Proposal** - Ternary operator behavior - https://github.com/hlsl-tc57/tc57/pull/122
+    * **New Proposal** - User-defined conversions - https://github.com/hlsl-tc57/tc57/pull/127
   * Stage Advancements - https://github.com/hlsl-tc57/tc57/pull/126
     * [0002 - Conforming
       Literals](https://github.com/hlsl-tc57/tc57/blob/main/proposals/0002-conforming-literals.md)

--- a/docs/Meetings/2026-07-07-agenda.md
+++ b/docs/Meetings/2026-07-07-agenda.md
@@ -23,8 +23,8 @@ title: "TC57 Meeting Agenda: 2026/07/07"
 
 # 2 Approval of prior meeting minutes
 
-* 2026-06-09 - https://github.com/hlsl-tc57/tc57/pull/129
-* 2026-06-23 - https://github.com/hlsl-tc57/tc57/pull/132
+* [2026-06-09](https://github.com/hlsl-tc57/tc57/pull/129)
+* [2026-06-23](https://github.com/hlsl-tc57/tc57/pull/132)
 
 # 3 Review of the agenda
 
@@ -34,23 +34,26 @@ title: "TC57 Meeting Agenda: 2026/07/07"
 
 # 6 Discussions
 
-* Roadmap View - https://github.com/orgs/hlsl-tc57/projects/1/
+* [Roadmap View](https://github.com/orgs/hlsl-tc57/projects/1/)
 * Chair Elections
 * New Proposals:
-  * **New Proposal** - Named casts - https://github.com/hlsl-tc57/tc57/pull/72
-  * **New Proposal** - `groupshared` arguments - https://github.com/hlsl-tc57/tc57/pull/73
-  * **New Proposal** - `const` non-static member functions - https://github.com/hlsl-tc57/tc57/pull/74
-  * **New Proposal** - non-member operator overloading - https://github.com/hlsl-tc57/tc57/pull/115
+  * **New Proposal** - [Named casts](https://github.com/hlsl-tc57/tc57/pull/72)
+  * **New Proposal** - [`groupshared` arguments](https://github.com/hlsl-tc57/tc57/pull/73)
+  * **New Proposal** - [`const` non-static member functions](https://github.com/hlsl-tc57/tc57/pull/74)
+  * **New Proposal** - [non-member operator overloading](https://github.com/hlsl-tc57/tc57/pull/115)
 * Normative language changes (Checking for consensus only)
-  * `Resources.TypedBuffer` - https://github.com/hlsl-tc57/tc57/pull/65
-  * Revised phrasing on code blocks - https://github.com/hlsl-tc57/tc57/pull/65/changes#diff-4bbc00ee5b9302369c65a12f120c15ceb5bddb718ad159846eae0c7c43ff70c7R13
+  * [`Resources.TypedBuffer`](https://github.com/hlsl-tc57/tc57/pull/65)
+  * [Revised phrasing on code blocks](https://github.com/hlsl-tc57/tc57/pull/65/changes#diff-4bbc00ee5b9302369c65a12f120c15ceb5bddb718ad159846eae0c7c43ff70c7R13)
 * For 2026-07-21
-  * **Normative Change** `[Lex.Identifier]` -
-    https://github.com/hlsl-tc57/tc57/pull/119
+  * **Normative Change**
+    [`[Lex.Identifier]`](https://github.com/hlsl-tc57/tc57/pull/119)
+  * **Normative Change**
+    [`[Lex.Keywords]`](https://github.com/hlsl-tc57/tc57/pull/133)
+  * **Normative Change** [`[Lex.Operators]`](https://github.com/hlsl-tc57/tc57/pull/135)
   * New Proposals:
-    * **New Proposal** - Ternary operator behavior - https://github.com/hlsl-tc57/tc57/pull/122
-    * **New Proposal** - User-defined conversions - https://github.com/hlsl-tc57/tc57/pull/127
-  * Stage Advancements - https://github.com/hlsl-tc57/tc57/pull/126
+    * **New Proposal** - [Ternary operator behavior](https://github.com/hlsl-tc57/tc57/pull/122)
+    * **New Proposal** - [User-defined conversions](https://github.com/hlsl-tc57/tc57/pull/127)
+  * [Stage Advancements](https://github.com/hlsl-tc57/tc57/pull/126)
     * [0002 - Conforming
       Literals](https://github.com/hlsl-tc57/tc57/blob/main/proposals/0002-conforming-literals.md)
       to **Completed**
@@ -63,15 +66,15 @@ title: "TC57 Meeting Agenda: 2026/07/07"
     * [0012 - Loop Unroll
       Factor](https://github.com/hlsl-tc57/tc57/blob/main/proposals/0012-hlsl-loop-unroll-factor.md)
       to **Refinement**
-* Draft Status - https://github.com/hlsl-tc57/tc57/issues/75
-  * Monthly report: https://hlsl-tc57.github.io/website/monthly/2026-06/
+* [Draft Status](https://github.com/hlsl-tc57/tc57/issues/75)
+  * [Monthly report](https://hlsl-tc57.github.io/website/monthly/2026-06/)
 * Committee Policy Questions from @pow2clk
   * Review Policy
   * AI Policy Clarifications
   * What is our approach to breaking changes?
   * How can we encourage multiple perspectives on HLSL proposals?
   * How do we decide what gets included in the HLSL spec at this point?
-* How does the committee want to handle removals? - https://github.com/hlsl-tc57/tc57/blob/main/proposals/0004-202x-removals.md
+* How does the committee want to handle removals? - [202x Removals](https://github.com/hlsl-tc57/tc57/blob/main/proposals/0004-202x-removals.md)
   * We have a growing list of removals, this is unlikely to be complete for a
     while. I'd like to avoid introducing specification language for things we
     want to remove, so how do we decide on this and ratify it?

--- a/docs/Meetings/2026-07-07-agenda.md
+++ b/docs/Meetings/2026-07-07-agenda.md
@@ -48,6 +48,28 @@ title: "TC57 Meeting Agenda: 2026/07/07"
     what should we allow?
 * For 2026-07-21
   * **Normative Change** `[Lex.Identifier]` - https://github.com/hlsl-tc57/tc57/pull/119
+  * Stage Advancements - https://github.com/hlsl-tc57/tc57/pull/126
+    * [0002 - Conforming
+      Literals](https://github.com/hlsl-tc57/tc57/blob/main/proposals/0002-conforming-literals.md)
+      to **Completed**
+    * [0007 - Memory and Executio
+      nodel](https://github.com/hlsl-tc57/tc57/blob/main/proposals/0007-mem-and-exec-model.md)
+      to **Refinement**
+    * [0008 - Numeric
+      Constants](https://github.com/hlsl-tc57/tc57/blob/main/proposals/0008-numeric-constants.md)
+      to **Refinement**
+    * [0009 - `hlsl`
+      namespace](https://github.com/hlsl-tc57/tc57/blob/main/proposals/0009-hlsl-namespace.md)
+      to **Refinement**
+    * [0010 - Modern
+      C++](https://github.com/hlsl-tc57/tc57/blob/main/proposals/0010-modern-cxx.md)
+      to **Refinement**
+    * [0011 - Strict
+      Initializers](https://github.com/hlsl-tc57/tc57/blob/main/proposals/0011-strict-initializer-lists.md)
+      to **Refinement**
+    * [0012 - Loop Unroll
+      Factor](https://github.com/hlsl-tc57/tc57/blob/main/proposals/0012-hlsl-loop-unroll-factor.md)
+      to **Refinement**
 
 
 # 7 Conclusions & Next Meeting

--- a/docs/Meetings/2026-07-07-agenda.md
+++ b/docs/Meetings/2026-07-07-agenda.md
@@ -4,7 +4,7 @@ title: "TC57 Meeting Agenda: 2026/07/07"
 
 |                 |                                                                    |
 |:----------------|:-------------------------------------------------------------------|
-| Agenda for the: | 8th meeting of Ecma TC57                                           |
+| Agenda for the: | 9th meeting of Ecma TC57                                           |
 | held in:        | Zoom (virtual)                                                     |
 | on:             | 07 Jul 2026                                                        |
 
@@ -27,7 +27,6 @@ title: "TC57 Meeting Agenda: 2026/07/07"
 
 # 4 Editorial Board Report
 
-
 # 5 Review New Proposals
 
 # 6 Discussions
@@ -46,8 +45,10 @@ title: "TC57 Meeting Agenda: 2026/07/07"
   * Conversions in initializer lists
   * Question about conversion operators - https://hlsl.godbolt.org/z/d4zWo59vf -
     what should we allow?
+* For 2026-07-21
+  * **Normative Change** `[Lex.Identifier]` - https://github.com/hlsl-tc57/tc57/pull/119
 
 
 # 7 Conclusions & Next Meeting
 
-Next meeting on 2026-07-07.
+Next meeting on 2026-07-21.

--- a/docs/Meetings/2026-07-07-agenda.md
+++ b/docs/Meetings/2026-07-07-agenda.md
@@ -41,6 +41,7 @@ title: "TC57 Meeting Agenda: 2026/07/07"
   * **New Proposal** - non-member operator overloading - https://github.com/hlsl-tc57/tc57/pull/115
 * Normative language changes
   * `Resources.TypedBuffer` - https://github.com/hlsl-tc57/tc57/pull/65
+  * Revised phrasing on code blocks - https://github.com/hlsl-tc57/tc57/pull/65/changes#diff-4bbc00ee5b9302369c65a12f120c15ceb5bddb718ad159846eae0c7c43ff70c7R13
 * Overload Resolution - https://github.com/hlsl-tc57/tc57/pull/62
   * Conversions in initializer lists
   * Question about conversion operators - https://hlsl.godbolt.org/z/d4zWo59vf -

--- a/docs/Meetings/2026-07-07-agenda.md
+++ b/docs/Meetings/2026-07-07-agenda.md
@@ -54,9 +54,6 @@ title: "TC57 Meeting Agenda: 2026/07/07"
     * [0002 - Conforming
       Literals](https://github.com/hlsl-tc57/tc57/blob/main/proposals/0002-conforming-literals.md)
       to **Completed**
-    * [0007 - Memory and Executio
-      nodel](https://github.com/hlsl-tc57/tc57/blob/main/proposals/0007-mem-and-exec-model.md)
-      to **Refinement**
     * [0008 - Numeric
       Constants](https://github.com/hlsl-tc57/tc57/blob/main/proposals/0008-numeric-constants.md)
       to **Refinement**

--- a/docs/Meetings/2026-07-07-agenda.md
+++ b/docs/Meetings/2026-07-07-agenda.md
@@ -69,8 +69,8 @@ title: "TC57 Meeting Agenda: 2026/07/07"
 * [Draft Status](https://github.com/hlsl-tc57/tc57/issues/75)
   * [Monthly report](https://hlsl-tc57.github.io/website/monthly/2026-06/)
 * Committee Policy Questions from @pow2clk
-  * Review Policy
   * AI Policy Clarifications
+  * Review Policy
   * What is our approach to breaking changes?
   * How can we encourage multiple perspectives on HLSL proposals?
   * How do we decide what gets included in the HLSL spec at this point?

--- a/docs/Meetings/2026-07-07-agenda.md
+++ b/docs/Meetings/2026-07-07-agenda.md
@@ -1,0 +1,53 @@
+---
+title: "TC57 Meeting Agenda: 2026/07/07"
+---
+
+|                 |                                                                    |
+|:----------------|:-------------------------------------------------------------------|
+| Agenda for the: | 8th meeting of Ecma TC57                                           |
+| held in:        | Zoom (virtual)                                                     |
+| on:             | 07 Jul 2026                                                        |
+
+|                 |                                                                    |
+|:----------------|:-------------------------------------------------------------------|
+| **Chair:**      | Chris Bieneman (Microsoft)                                         |
+| **Vice-chair:** | Farzon Lotfi (Microsoft)                                           |
+| **Secretary:**  | Aki Braun (Ecma International), Samina Husain (Ecma International) |
+
+# 1 Welcome, opening and meeting logistics
+
+* TC57 meetings are recorded for the purpose of note-taking, recordings are deleted after minutes are prepared. Please see the [video recording and legal disclaimer](../Meetings.md#video-recording-meeting-minutes-and-legal-disclaimer) for more information.
+* We have a [Code of Conduct](/docs/CodeOfConduct.md).
+* TC57 is part of Ecma and operates under Ecma's [Royalty-Free patent policy](https://ecma-international.org/wp-content/uploads/Ecma_Royalty-Free_Patent_Policy_Extension_Option.pdf). All delegates from participating companies should have already agreed to the policy. The same is true for all invited experts. Anyone who is not a delegate or invited expert we ask to please not speak or utilize the in-meeting chat features.
+* Ecma's IPR policies are all [available online](https://ecma-international.org/policies/by-ipr/)
+
+# 2 Approval of prior meeting minutes
+
+# 3 Review of the agenda
+
+# 4 Editorial Board Report
+
+
+# 5 Review New Proposals
+
+# 6 Discussions
+
+* Roadmap View - https://github.com/orgs/hlsl-tc57/projects/1/
+* Draft Status - https://github.com/hlsl-tc57/tc57/issues/75
+* New Proposals:
+  * **New Proposal** - Named casts - https://github.com/hlsl-tc57/tc57/pull/72
+  * **New Proposal** - `groupshared` arguments - https://github.com/hlsl-tc57/tc57/pull/73
+  * **New Proposal** - `const` non-static member functions - https://github.com/hlsl-tc57/tc57/pull/74
+  * **New Proposal** - non-member operator overloading - https://github.com/hlsl-tc57/tc57/pull/115
+* Normative language changes
+  * `Resources.TypedBuffer` - https://github.com/hlsl-tc57/tc57/pull/65
+* Overload Resolution - https://github.com/hlsl-tc57/tc57/pull/62
+  * Conversions in initializer lists
+  * Question about conversion operators - https://hlsl.godbolt.org/z/d4zWo59vf -
+    what should we allow?
+
+
+
+# 7 Conclusions & Next Meeting
+
+Next meeting on 2026-07-07.

--- a/docs/Meetings/2026-07-07-agenda.md
+++ b/docs/Meetings/2026-07-07-agenda.md
@@ -42,6 +42,12 @@ title: "TC57 Meeting Agenda: 2026/07/07"
   * **New Proposal** - `groupshared` arguments - https://github.com/hlsl-tc57/tc57/pull/73
   * **New Proposal** - `const` non-static member functions - https://github.com/hlsl-tc57/tc57/pull/74
   * **New Proposal** - non-member operator overloading - https://github.com/hlsl-tc57/tc57/pull/115
+* Committee Policy Questions from @pow2clk
+  * Review Policy
+  * AI Policy Clarifications
+  * What is our approach to breaking changes?
+  * How can we encourage multiple perspectives on HLSL proposals?
+  * How do we decide what gets included in the HLSL spec at this point?
 * How does the committee want to handle removals? - https://github.com/hlsl-tc57/tc57/blob/main/proposals/0004-202x-removals.md
   * We have a growing list of removals, this is unlikely to be complete for a
     while. I'd like to avoid introducing specification language for things we

--- a/docs/Meetings/2026-07-07-agenda.md
+++ b/docs/Meetings/2026-07-07-agenda.md
@@ -60,12 +60,6 @@ title: "TC57 Meeting Agenda: 2026/07/07"
     * [0009 - `hlsl`
       namespace](https://github.com/hlsl-tc57/tc57/blob/main/proposals/0009-hlsl-namespace.md)
       to **Refinement**
-    * [0010 - Modern
-      C++](https://github.com/hlsl-tc57/tc57/blob/main/proposals/0010-modern-cxx.md)
-      to **Refinement**
-    * [0011 - Strict
-      Initializers](https://github.com/hlsl-tc57/tc57/blob/main/proposals/0011-strict-initializer-lists.md)
-      to **Refinement**
     * [0012 - Loop Unroll
       Factor](https://github.com/hlsl-tc57/tc57/blob/main/proposals/0012-hlsl-loop-unroll-factor.md)
       to **Refinement**

--- a/docs/Meetings/2026-07-07-agenda.md
+++ b/docs/Meetings/2026-07-07-agenda.md
@@ -39,6 +39,10 @@ title: "TC57 Meeting Agenda: 2026/07/07"
   * **New Proposal** - `groupshared` arguments - https://github.com/hlsl-tc57/tc57/pull/73
   * **New Proposal** - `const` non-static member functions - https://github.com/hlsl-tc57/tc57/pull/74
   * **New Proposal** - non-member operator overloading - https://github.com/hlsl-tc57/tc57/pull/115
+* How does the committee want to handle removals? - https://github.com/hlsl-tc57/tc57/blob/main/proposals/0004-202x-removals.md
+  * We have a growing list of removals, this is unlikely to be complete for a
+    while. I'd like to avoid introducing specification language for things we
+    want to remove, so how do we decide on this and ratify it?
 * Normative language changes
   * `Resources.TypedBuffer` - https://github.com/hlsl-tc57/tc57/pull/65
   * Revised phrasing on code blocks - https://github.com/hlsl-tc57/tc57/pull/65/changes#diff-4bbc00ee5b9302369c65a12f120c15ceb5bddb718ad159846eae0c7c43ff70c7R13

--- a/docs/Meetings/2026-07-07-agenda.md
+++ b/docs/Meetings/2026-07-07-agenda.md
@@ -35,30 +35,15 @@ title: "TC57 Meeting Agenda: 2026/07/07"
 # 6 Discussions
 
 * Roadmap View - https://github.com/orgs/hlsl-tc57/projects/1/
-* Draft Status - https://github.com/hlsl-tc57/tc57/issues/75
 * Chair Elections
 * New Proposals:
   * **New Proposal** - Named casts - https://github.com/hlsl-tc57/tc57/pull/72
   * **New Proposal** - `groupshared` arguments - https://github.com/hlsl-tc57/tc57/pull/73
   * **New Proposal** - `const` non-static member functions - https://github.com/hlsl-tc57/tc57/pull/74
   * **New Proposal** - non-member operator overloading - https://github.com/hlsl-tc57/tc57/pull/115
-* Committee Policy Questions from @pow2clk
-  * Review Policy
-  * AI Policy Clarifications
-  * What is our approach to breaking changes?
-  * How can we encourage multiple perspectives on HLSL proposals?
-  * How do we decide what gets included in the HLSL spec at this point?
-* How does the committee want to handle removals? - https://github.com/hlsl-tc57/tc57/blob/main/proposals/0004-202x-removals.md
-  * We have a growing list of removals, this is unlikely to be complete for a
-    while. I'd like to avoid introducing specification language for things we
-    want to remove, so how do we decide on this and ratify it?
-* Normative language changes
+* Normative language changes (Checking for consensus only)
   * `Resources.TypedBuffer` - https://github.com/hlsl-tc57/tc57/pull/65
   * Revised phrasing on code blocks - https://github.com/hlsl-tc57/tc57/pull/65/changes#diff-4bbc00ee5b9302369c65a12f120c15ceb5bddb718ad159846eae0c7c43ff70c7R13
-* Overload Resolution - https://github.com/hlsl-tc57/tc57/pull/62
-  * Conversions in initializer lists
-  * Question about conversion operators - https://hlsl.godbolt.org/z/d4zWo59vf -
-    what should we allow?
 * For 2026-07-21
   * **Normative Change** `[Lex.Identifier]` -
     https://github.com/hlsl-tc57/tc57/pull/119
@@ -87,6 +72,18 @@ title: "TC57 Meeting Agenda: 2026/07/07"
     * [0012 - Loop Unroll
       Factor](https://github.com/hlsl-tc57/tc57/blob/main/proposals/0012-hlsl-loop-unroll-factor.md)
       to **Refinement**
+* Draft Status - https://github.com/hlsl-tc57/tc57/issues/75
+  * Monthly report: https://hlsl-tc57.github.io/website/monthly/2026-06/
+* Committee Policy Questions from @pow2clk
+  * Review Policy
+  * AI Policy Clarifications
+  * What is our approach to breaking changes?
+  * How can we encourage multiple perspectives on HLSL proposals?
+  * How do we decide what gets included in the HLSL spec at this point?
+* How does the committee want to handle removals? - https://github.com/hlsl-tc57/tc57/blob/main/proposals/0004-202x-removals.md
+  * We have a growing list of removals, this is unlikely to be complete for a
+    while. I'd like to avoid introducing specification language for things we
+    want to remove, so how do we decide on this and ratify it?
 
 
 # 7 Conclusions & Next Meeting

--- a/docs/Meetings/2026-07-07-agenda.md
+++ b/docs/Meetings/2026-07-07-agenda.md
@@ -19,7 +19,7 @@ title: "TC57 Meeting Agenda: 2026/07/07"
 * TC57 meetings are recorded for the purpose of note-taking, recordings are deleted after minutes are prepared. Please see the [video recording and legal disclaimer](../Meetings.md#video-recording-meeting-minutes-and-legal-disclaimer) for more information.
 * We have a [Code of Conduct](/docs/CodeOfConduct.md).
 * TC57 is part of Ecma and operates under Ecma's [Royalty-Free patent policy](https://ecma-international.org/wp-content/uploads/Ecma_Royalty-Free_Patent_Policy_Extension_Option.pdf). All delegates from participating companies should have already agreed to the policy. The same is true for all invited experts. Anyone who is not a delegate or invited expert we ask to please not speak or utilize the in-meeting chat features.
-* Ecma's IPR policies are all [available online](https://ecma-international.org/policies/by-ipr/)
+* Ecma's IPR policies are all [available online](https://ecma-international.org/policies/by-ipr/).
 
 # 2 Approval of prior meeting minutes
 

--- a/docs/Meetings/2026-07-07-agenda.md
+++ b/docs/Meetings/2026-07-07-agenda.md
@@ -52,6 +52,7 @@ title: "TC57 Meeting Agenda: 2026/07/07"
     what should we allow?
 * For 2026-07-21
   * **Normative Change** `[Lex.Identifier]` - https://github.com/hlsl-tc57/tc57/pull/119
+  * **New Proposal** - Ternary operator behavior - https://github.com/hlsl-tc57/tc57/pull/122
   * Stage Advancements - https://github.com/hlsl-tc57/tc57/pull/126
     * [0002 - Conforming
       Literals](https://github.com/hlsl-tc57/tc57/blob/main/proposals/0002-conforming-literals.md)

--- a/docs/Meetings/2026-07-07-agenda.md
+++ b/docs/Meetings/2026-07-07-agenda.md
@@ -34,6 +34,7 @@ title: "TC57 Meeting Agenda: 2026/07/07"
 
 * Roadmap View - https://github.com/orgs/hlsl-tc57/projects/1/
 * Draft Status - https://github.com/hlsl-tc57/tc57/issues/75
+* Chair Elections
 * New Proposals:
   * **New Proposal** - Named casts - https://github.com/hlsl-tc57/tc57/pull/72
   * **New Proposal** - `groupshared` arguments - https://github.com/hlsl-tc57/tc57/pull/73
@@ -45,7 +46,6 @@ title: "TC57 Meeting Agenda: 2026/07/07"
   * Conversions in initializer lists
   * Question about conversion operators - https://hlsl.godbolt.org/z/d4zWo59vf -
     what should we allow?
-
 
 
 # 7 Conclusions & Next Meeting


### PR DESCRIPTION
This adds the agenda for the 2026-07-07 meeting to be reviewed and approved at the beginning of the meeting.

Add any proposed topics via suggestions against this PR.