### PR TITLE
[Website] Add missing document title

### DIFF
--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -1,3 +1,6 @@
+---
+title: Building the Spec and Website
+---
 # Building the HLSL TC57 Website with Docker
 
 This Dockerfile builds the complete HLSL TC57 website, including both the Hugo static site and the LaTeX specification.


### PR DESCRIPTION
This fixes a missing document title causing oddities in the hugo build.