### PR TITLE
[Lex.Operators] Add lexing rules for operators

### DIFF
--- a/spec/lex.tex
+++ b/spec/lex.tex
@@ -224,10 +224,12 @@ period.
   \define{preprocessing-op-or-punc}\br
     preprocessing-operator\br
     operator-or-punctuator
+    
   \define{preprocessing-operator}\br
     \terminal{\#}\br
     \terminal{\#\#}
-  \define{operator-or-punctuator}\textnormal{one of}\br
+    
+  \define{operator-or-punctuator} \textnormal{one of}\br
     \terminal{\{ \} [ ] ( ) ; : ...}\br
     \terminal{? :: . ~}\br
     \terminal{! + - * / \% \^ \& |}\br

--- a/spec/lex.tex
+++ b/spec/lex.tex
@@ -225,14 +225,14 @@ period.
     preprocessing-operator\br
     operator-or-punctuator
   \define{preprocessing-operator}\br
-    \terminal{#}\br
-    \terminal{##}
+    \terminal{\#}\br
+    \terminal{\#\#}
   \define{operator-or-punctuator}\textnormal{one of}\br
     \terminal{\{ \} [ ] ( ) ; : ...}\br
     \terminal{? :: . ~}\br
-    \terminal{! + - * / \% ^ & |}\br
-    \terminal{= += -= *= /= \%= ^= &= |=}\br
-    \terminal{== += < > <= >= && ||}\br
+    \terminal{! + - * / \% \^ \& |}\br
+    \terminal{= += -= *= /= \%= \^= \&= |=}\br
+    \terminal{== += < > <= >= \&\& ||}\br
     \terminal{<< >> <<= >>= ++ -- ,}
 \end{grammar}
 

--- a/spec/lex.tex
+++ b/spec/lex.tex
@@ -218,7 +218,31 @@ period.
 
 %TODO: \Sec{Keywords}{Lex.Keywords}
 
-%TODO: \Sec{Operators and Punctuators}{Lex.Operators}
+\Sec{Operators and Punctuators}{Lex.Operators}
+
+\begin{grammar}
+  \define{preprocessing-op-or-punc}\br
+    preprocessing-operator\br
+    operator-or-punctuator
+  \define{preprocessing-operator}\br
+    \terminal{#}\br
+    \terminal{##}
+  \define{operator-or-punctuator}\textnormal{one of}\br
+    \terminal{\{ \} [ ] ( ) ; : ...}\br
+    \terminal{? :: . ~}\br
+    \terminal{! + - * / \% ^ & |}\br
+    \terminal{= += -= *= /= \%= ^= &= |=}\br
+    \terminal{== += < > <= >= && ||}\br
+    \terminal{<< >> <<= >>= ++ -- ,}
+\end{grammar}
+
+\p HLSL inherits a set of operators and punctuators from \gls{isoCPP}. The set
+of tokens in the \textit{preprocessing-op-or-punc} grammar formation are either
+interpreted by the preprocessor (\ref{Preprocessing}), or they are converted to
+tokens.
+
+\p Each \textit{operator-or-punctuator} that is not handled completely by the
+preprocessor is converted to a single token.
 
 \Sec{Literals}{Lex.Literals}
 


### PR DESCRIPTION
The notable difference between HLSL and C/C++ here is that I've excluded digraph and trigraph tokens. I'm sure we don't need those right?